### PR TITLE
[WIP/EXPERIMENTAL] feat: persistent mocks over WS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ firestore-debug.log
 
 # Local Netlify folder
 .netlify
+
+# Mock database
+shared/mocks/mock-db.json

--- a/apps/tedris/app/cards/[id]/page.tsx
+++ b/apps/tedris/app/cards/[id]/page.tsx
@@ -17,6 +17,8 @@ export default async function Card({
     return <div>Error: {error}</div>;
   }
 
+  console.log(card)
+
   return (
     <div>
       <ul>

--- a/apps/tedris/app/cards/page.tsx
+++ b/apps/tedris/app/cards/page.tsx
@@ -1,18 +1,38 @@
-import { cookies } from "next/headers";
-import Link from "next/link";
-import { getAuthenticatedApiService } from "~/lib/services";
+'use client';
 
-export default async function Cards() {
-  const cookieStore = await cookies();
-  const api = getAuthenticatedApiService(cookieStore);
-  const { data: cards, error } = await api.getCards();
+import { Button } from "@madrasah/ui/components/button";
+import Link from "next/link";
+import { useApi, useQuery } from "~/hooks";
+
+export default function Cards() {
+  const {api} = useApi();
+  const { data: cards, isLoading, error } = useQuery(api => api.getCards(), {});
+
+  if(isLoading){
+    return <div>Loading...</div>;
+  }
 
   if (error) {
     return <div>Error: {error}</div>;
   }
 
+  const onClickCreateCard = () => {
+    api.createCard({
+      id: Math.floor(Math.random() * 100000),
+      is_public: true,
+      author_id: Math.floor(Math.random() * 100000),
+      content: {
+        front: "New Card",
+        back: "Card Content",
+      },
+      type: "hadeeth",
+      image_source: "https://via.placeholder.com/150",
+    });
+  };
+
   return (
     <div>
+      <Button onClick={onClickCreateCard}>Create random card</Button>
       <ul>
         {cards.map((card) => (
           <Link href={`/cards/${card.id}`} key={card.id}>

--- a/apps/tedris/next-env.d.ts
+++ b/apps/tedris/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "esbuild": "^0.25.9",
         "husky": "^9.1.7",
         "jiti": "^2.5.1",
+        "npm-run-all": "^4.1.5",
         "prettier": "^3.6.2",
         "turbo": "^2.5.6"
       }
@@ -2332,6 +2333,31 @@
       "resolved": "shared/utils",
       "link": true
     },
+    "node_modules/@mswjs/data": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@mswjs/data/-/data-0.16.2.tgz",
+      "integrity": "sha512-/C0d/PBcJyQJokUhcjO4HiZPc67hzllKlRtD1XELygl2t991/ATAAQJVcStn4YtVALsNodruzOHT0JIvgr0hnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.14.172",
+        "@types/md5": "^2.3.0",
+        "@types/pluralize": "^0.0.29",
+        "@types/uuid": "^8.3.0",
+        "date-fns": "^2.21.1",
+        "debug": "^4.3.1",
+        "graphql": "^16.8.1",
+        "lodash": "^4.17.21",
+        "md5": "^2.3.0",
+        "outvariant": "^1.2.1",
+        "pluralize": "^8.0.0",
+        "strict-event-emitter": "^0.5.0",
+        "uuid": "^8.3.1"
+      },
+      "optionalDependencies": {
+        "msw": "^2.0.8"
+      }
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.39.6",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.6.tgz",
@@ -4163,6 +4189,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/md5": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.5.tgz",
+      "integrity": "sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "dev": true,
@@ -4175,6 +4215,13 @@
       "dependencies": {
         "undici-types": "~7.10.0"
       }
+    },
+    "node_modules/@types/pluralize": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
+      "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -4234,6 +4281,23 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.40.0",
@@ -5130,6 +5194,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "dev": true,
@@ -5427,6 +5501,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "devOptional": true,
@@ -5502,6 +5586,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -7773,6 +7874,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "dev": true,
@@ -8118,6 +8226,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
@@ -8631,6 +8746,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "dev": true,
@@ -8993,6 +9115,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/load-json-file/node_modules/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "7.2.0",
       "dev": true,
@@ -9184,6 +9336,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/meow": {
@@ -9647,6 +9820,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nizam-web": {
       "resolved": "apps/nizam",
       "link": true
@@ -9739,12 +9919,226 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/normalize-range": {
       "version": "0.1.2",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-all/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/npm-run-path": {
@@ -10233,6 +10627,39 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "dev": true,
@@ -10570,6 +10997,34 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/read-pkg/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/readable-stream": {
@@ -11051,6 +11506,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/shimmer": {
       "version": "1.2.1",
       "license": "BSD-2-Clause",
@@ -11208,6 +11676,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "dev": true,
@@ -11341,6 +11845,25 @@
         "regexp.prototype.flags": "^1.5.3",
         "set-function-name": "^2.0.2",
         "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12221,6 +12744,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
       "dev": true,
@@ -12497,6 +13031,8 @@
     },
     "node_modules/ws": {
       "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12781,7 +13317,10 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^9.9.0",
-        "msw": "^2.10.5"
+        "@mswjs/data": "^0.16.2",
+        "@types/ws": "^8.18.1",
+        "msw": "^2.10.5",
+        "ws": "^8.18.3"
       }
     },
     "shared/services": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   ],
   "scripts": {
     "build": "turbo build",
-    "dev": "turbo dev",
+    "dev": "npm-run-all --parallel dev:apps dev:mock-server",
+    "dev:apps": "turbo dev",
+    "dev:mock-server": "npm run start-server --workspace=@madrasah/msw",
     "lint": "turbo lint",
     "check-types": "turbo run check-types",
     "lint:fix": "turbo lint -- --fix",
@@ -23,6 +25,7 @@
     "esbuild": "^0.25.9",
     "husky": "^9.1.7",
     "jiti": "^2.5.1",
+    "npm-run-all": "^4.1.5",
     "prettier": "^3.6.2",
     "turbo": "^2.5.6"
   },

--- a/shared/mocks/mock-ws-server.ts
+++ b/shared/mocks/mock-ws-server.ts
@@ -1,0 +1,91 @@
+import { WebSocketServer, WebSocket } from 'ws'
+import { promises as fs } from 'fs'
+import path from 'path'
+
+const dbPath = path.join(process.cwd(), 'mock-db.json')
+const wss = new WebSocketServer({
+  port: 8080,
+  // Disable per-message deflate compression. This prevents the server from
+  // trying to use native addons like `bufferutil`, which can cause crashes
+  // in some development environments like the one in Next.js.
+  perMessageDeflate: false,
+})
+
+let dbState: Record<string, unknown> = {}
+
+// Read the initial state from the file system.
+const loadInitialState = async () => {
+  try {
+    const data = await fs.readFile(dbPath, 'utf-8')
+    dbState = JSON.parse(data)
+    console.log('✅ Mock DB state loaded from', dbPath)
+  }
+  catch (error) {
+    const nodeError = error as NodeJS.ErrnoException
+    if (nodeError.code === 'ENOENT') {
+      console.log('ℹ️ No mock DB file found, starting with empty state.')
+    }
+    else {
+      console.error('❌ Failed to read mock DB file:', error)
+    }
+  }
+}
+
+const persistState = async () => {
+  try {
+    await fs.writeFile(dbPath, JSON.stringify(dbState, null, 2))
+  }
+  catch (error) {
+    console.error('❌ Failed to write mock DB file:', error)
+  }
+}
+
+wss.on('connection', (ws) => {
+  console.log('🔌 Mock DB client connected')
+
+  ws.on('message', (message) => {
+    const { type, payload } = JSON.parse(message.toString())
+
+    switch (type) {
+      case 'GET_ITEM': {
+        const { key } = payload
+        const value = dbState[key]
+        ws.send(
+          JSON.stringify({
+            type: 'GET_ITEM_SUCCESS',
+            payload: { key, value },
+          }),
+        )
+        break
+      }
+      case 'SET_ITEM': {
+        const { key, value } = payload
+        dbState[key] = value
+        persistState()
+
+        // Broadcast the update to all other connected clients
+        wss.clients.forEach((client) => {
+          if (client !== ws && client.readyState === WebSocket.OPEN) {
+            client.send(
+              JSON.stringify({
+                type: 'STATE_UPDATED',
+                payload: { key, value },
+              }),
+            )
+          }
+        })
+
+        ws.send(JSON.stringify({ type: 'SET_ITEM_SUCCESS', payload: { key } }))
+        break
+      }
+    }
+  })
+
+  ws.on('close', () => {
+    console.log('🔌 Mock DB client disconnected')
+  })
+})
+
+loadInitialState().then(() => {
+  console.log('🚀 Mock WebSocket server listening on ws://localhost:8080')
+})

--- a/shared/mocks/package.json
+++ b/shared/mocks/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "type": "module",
   "main": "index.js",
- "exports": {
+  "scripts": {
+    "start-server": "node --loader ts-node/esm mock-ws-server.ts"
+  },
+  "exports": {
     "./tedrisat": {
       "types": "./src/tedrisat/index.ts",
       "import": "./src/tedrisat/index.ts",
@@ -12,7 +15,10 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.9.0",
-    "msw": "^2.10.5"
+    "@mswjs/data": "^0.16.2",
+    "@types/ws": "^8.18.1",
+    "msw": "^2.10.5",
+    "ws": "^8.18.3"
   },
   "dependencies": {
     "@madrasah/services": "^0.1.0"

--- a/shared/mocks/src/tedrisat/db.ts
+++ b/shared/mocks/src/tedrisat/db.ts
@@ -1,0 +1,49 @@
+import { factory, primaryKey } from '@mswjs/data'
+import { faker } from '@faker-js/faker'
+import persist from '../utils/persist'
+import { createWebSocketStorage } from '../utils/wsStorageAdapter'
+
+const storage = createWebSocketStorage()
+
+export const db = factory({
+  card: {
+    id: primaryKey(faker.number.int),
+    author_id: faker.number.int,
+    is_public: faker.datatype.boolean,
+    content: {
+      front: faker.word.adjective,
+      back: faker.lorem.paragraphs,
+    },
+    type: () => faker.helpers.arrayElement(['hadeeth', 'vocabulary']),
+    image_source: () => faker.image.urlLoremFlickr({ category: 'nature' }),
+  },
+  list: {
+    id: primaryKey(faker.number.int),
+    author_id: faker.number.int,
+    is_public: faker.datatype.boolean,
+    title: faker.lorem.words,
+    description: faker.lorem.sentence,
+  },
+})
+
+persist(db, storage)
+
+setTimeout(() => {
+  if (db.card.count() === 0) {
+    db.card.create({
+      id: 1,
+      content: {
+        front: 'Selam',
+        back: 'Barış, esenlik',
+      },
+    })
+  }
+
+  if (db.list.count() === 0) {
+    db.list.create({
+      id: 1,
+      title: 'My First List',
+      description: 'A list of things to learn',
+    })
+  }
+}, 1000) // Asenkron hidrasyona izin vermek için tohumlamayı geciktir

--- a/shared/mocks/src/tedrisat/faker.ts
+++ b/shared/mocks/src/tedrisat/faker.ts
@@ -1,42 +1,40 @@
-import { Card, List } from '@madrasah/services/tedrisat';
-import { en, Faker } from '@faker-js/faker';
+import { Card, List } from '@madrasah/services/tedrisat'
+import { en, Faker } from '@faker-js/faker'
 
 export const tedrisat = {
   cardType(): string {
-    return faker.helpers.arrayElement(['Başlangıç', 'Orta Seviye', 'İleri Seviye']);
+    return faker.helpers.arrayElement(['Başlangıç', 'Orta Seviye', 'İleri Seviye'])
   },
 
-  card(id?: number): Card {
-    if(id) faker.seed(id);
-
+  card(): Card {
     return {
-        id: id ?? faker.number.int(),
-        author_id: faker.number.int(),
-        is_public: faker.datatype.boolean(),
-        content: {
-          front: faker.word.adjective(),
-          back: faker.lorem.paragraphs(1),
-        },
-        type: faker.helpers.arrayElement(['hadeeth', 'vocabulary']),
-        image_source: faker.image.urlLoremFlickr({ category: 'nature', width: 640, height: 480 }),
-    };
+      id: faker.number.int(),
+      author_id: faker.number.int(),
+      is_public: faker.datatype.boolean(),
+      content: {
+        front: faker.word.adjective(),
+        back: faker.lorem.paragraphs(1),
+      },
+      type: faker.helpers.arrayElement(['hadeeth', 'vocabulary']),
+      image_source: faker.image.urlLoremFlickr({ category: 'nature', width: 640, height: 480 }),
+    }
   },
 
   list(id?: number): List {
-    if(id) faker.seed(id);
+    if (id) faker.seed(id)
 
     return {
-        id: id ?? faker.number.int(),
-        author_id: faker.number.int(),
-        is_public: faker.datatype.boolean(),
-        title: faker.lorem.words(3),
-        description: faker.lorem.sentence()
-    };
-  }
-};
+      id: id ?? faker.number.int(),
+      author_id: faker.number.int(),
+      is_public: faker.datatype.boolean(),
+      title: faker.lorem.words(3),
+      description: faker.lorem.sentence(),
+    }
+  },
+}
 
-export type MadrasahFaker = Faker & { tedrisat: typeof tedrisat; };
-const faker: MadrasahFaker = new Faker({ locale: en }) as MadrasahFaker;
-faker.tedrisat = tedrisat;
+export type MadrasahFaker = Faker & { tedrisat: typeof tedrisat }
+const faker: MadrasahFaker = new Faker({ locale: en }) as MadrasahFaker
+faker.tedrisat = tedrisat
 
-export { faker };
+export { faker }

--- a/shared/mocks/src/tedrisat/handlers/tedrisat.ts
+++ b/shared/mocks/src/tedrisat/handlers/tedrisat.ts
@@ -1,40 +1,49 @@
-import { http, HttpResponse } from 'msw';
-import { MockApiHandlers } from '../../types';
+import { http, HttpResponse } from 'msw'
+import { db } from '../db'
+import { MockApiHandlers } from '../../types'
 
-import { faker } from '../faker';
-import type { Card, List, TedrisatService } from '@madrasah/services/tedrisat';
+import type { Card, TedrisatService } from '@madrasah/services/tedrisat'
 
 /**
 * This is a factory function that creates HTTP handlers for mocking API endpoints.
 */
 export const tedrisatHandlers = (baseUrl: string): MockApiHandlers<TedrisatService> => {
   if (!baseUrl) {
-    throw new Error("Base URL is required to create mock API handlers.");
+    throw new Error('Base URL is required to create mock API handlers.')
   }
 
   const handlers: MockApiHandlers<TedrisatService> = {
     getCards: http.get(`${baseUrl}/cards`, (): HttpResponse<Card[]> => {
-      const posts = faker.helpers.multiple((_, index) => faker.tedrisat.card(index + 1), { count: 10 })
-      return HttpResponse.json(posts)
+      const cards = db.card.getAll()
+      return HttpResponse.json(cards)
     }),
-    getCard: http.get(`${baseUrl}/cards/:id`, ({params: {id}}): HttpResponse<Card> => {
-      const card = faker.tedrisat.card(Number(id))
+    getCard: http.get(`${baseUrl}/cards/:id`, ({ params: { id } }): HttpResponse<Card> => {
+      const card = db.card.findFirst({
+        where: { id: { equals: Number(id) } },
+      })
       return HttpResponse.json(card)
     }),
-    getListCards: http.get(`${baseUrl}/cards/list`, (): HttpResponse<Card[]> => {
-      const posts = faker.helpers.multiple((_, index) => faker.tedrisat.card(index + 1), { count: 10 })
-      return HttpResponse.json(posts)
+    createCard: http.post(`${baseUrl}/cards`, async (req) => {
+      const card = await req.request.json() as Card
+      db.card.create(card)
+      return HttpResponse.json(card)
     }),
-    getLists: http.get(`${baseUrl}/lists`, (): HttpResponse<List[]> => {
-      const lists = faker.helpers.multiple((_, index) => faker.tedrisat.list(index + 1), { count: 10 })
+
+    getListCards: http.get(`${baseUrl}/cards/list`, () => {
+      const cards = db.card.getAll()
+      return HttpResponse.json(cards)
+    }),
+    getLists: http.get(`${baseUrl}/lists`, () => {
+      const lists = db.list.getAll()
       return HttpResponse.json(lists)
     }),
-    getList: http.get(`${baseUrl}/lists/:id`, ({params: {id}}): HttpResponse<List> => {
-      const list = faker.tedrisat.list(Number(id));
+    getList: http.get(`${baseUrl}/lists/:id`, ({ params: { id } }) => {
+      const list = db.list.findFirst({
+        where: { id: { equals: Number(id) } },
+      })
       return HttpResponse.json(list)
     }),
-
   }
 
-  return handlers;
-};
+  return handlers
+}

--- a/shared/mocks/src/utils/persist.ts
+++ b/shared/mocks/src/utils/persist.ts
@@ -1,0 +1,97 @@
+import debounce from 'lodash/debounce'
+import {
+  DATABASE_INSTANCE,
+  ENTITY_TYPE,
+  PRIMARY_KEY,
+  type FactoryAPI,
+  type Entity,
+  type ModelDictionary,
+  type PrimaryKeyType,
+} from '@mswjs/data/lib/glossary'
+import {
+  type SerializedEntity,
+  SERIALIZED_INTERNAL_PROPERTIES_KEY,
+} from '@mswjs/data/lib/db/Database'
+import { inheritInternalProperties } from '@mswjs/data/lib/utils/inheritInternalProperties'
+
+// Timout to persist state with some delay
+const DEBOUNCE_PERSIST_TIME_MS = 10
+
+type Models<Dictionary extends ModelDictionary> = Record<
+  keyof Dictionary,
+  Map<PrimaryKeyType, Entity<Dictionary, any>>
+>
+
+type SerializedModels<Dictionary extends ModelDictionary> = Record<
+  keyof Dictionary,
+  Array<SerializedEntity>
+>
+
+export interface StorageAdapter {
+  getItem(key: string): string | null | Promise<string | null>
+  setItem(key: string, value: string): void | Promise<void>
+}
+
+export default function persist<Dictionary extends ModelDictionary>(
+  factory: FactoryAPI<Dictionary>,
+  storage: StorageAdapter,
+) {
+  const db = factory[DATABASE_INSTANCE]
+
+  const key = `mswjs-data/${db.id}`
+
+  const persistState = debounce(async function persistState() {
+    const models = db['models'] as Models<Dictionary>
+
+    const serializeEntity = db['serializeEntity'] as (
+      entity: Entity<Dictionary, any>,
+    ) => SerializedEntity
+
+    const json = Object.fromEntries(
+      Object.entries(models).map(([modelName, entities]) => [
+        modelName,
+        Array.from(entities, ([, entity]) => serializeEntity(entity)),
+      ]),
+    )
+
+    await storage.setItem(key, JSON.stringify(json))
+  }, DEBOUNCE_PERSIST_TIME_MS)
+
+  async function hydrateState() {
+    const initialState = await storage.getItem(key)
+
+    if (initialState) {
+      const data = JSON.parse(initialState) as SerializedModels<Dictionary>
+
+      for (const [modelName, entities] of Object.entries(data)) {
+        for (const entity of entities) {
+          // Avoid creating duplicates during hydration
+          if (!db.has(modelName, entity.id)) {
+            db.create(modelName, deserializeEntity(entity))
+          }
+        }
+      }
+    }
+
+    // Add event listeners only after hydration
+    db.events.on('create', persistState)
+    db.events.on('update', persistState)
+    db.events.on('delete', persistState)
+  }
+
+  hydrateState()
+}
+
+function deserializeEntity(entity: SerializedEntity) {
+  const {
+    [SERIALIZED_INTERNAL_PROPERTIES_KEY]: internalProperties,
+    ...publicProperties
+  } = entity
+
+  inheritInternalProperties(publicProperties, {
+    [ENTITY_TYPE]: internalProperties.entityType,
+    [PRIMARY_KEY]: internalProperties.primaryKey,
+  })
+
+  return publicProperties as Entity<any, any>
+}

--- a/shared/mocks/src/utils/wsStorageAdapter.ts
+++ b/shared/mocks/src/utils/wsStorageAdapter.ts
@@ -52,7 +52,12 @@ export const createWebSocketStorage = (): StorageAdapter => {
         if (type === 'GET_ITEM_SUCCESS') {
           const resolveFunc = pendingRequests.get(key)
           if (resolveFunc) {
-            resolveFunc(value ? JSON.stringify(value) : null)
+            if (typeof resolveFunc === 'function') {
+              resolveFunc(value ? JSON.stringify(value) : null)
+            }
+            else {
+              console.warn(`Expected pendingRequests entry for key "${key}" to be a function, got:`, resolveFunc)
+            }
             pendingRequests.delete(key)
           }
         }

--- a/shared/mocks/src/utils/wsStorageAdapter.ts
+++ b/shared/mocks/src/utils/wsStorageAdapter.ts
@@ -1,0 +1,86 @@
+import { type StorageAdapter } from './persist'
+
+const WS_ENDPOINT = 'ws://localhost:8080'
+
+type WsMessage = {
+  type: string
+  payload: {
+    key: string
+    value?: unknown
+  }
+}
+
+/**
+ * An adapter that uses a WebSocket connection to synchronize the mock DB state.
+ * Both the browser and server MSW instances will use this to communicate with
+ * the central WebSocket server.
+ */
+export const createWebSocketStorage = (): StorageAdapter => {
+  let ws: WebSocket | null = null
+  let isConnecting = false
+  const requestQueue: Array<() => void> = []
+  const pendingRequests = new Map<string, (value: string | null) => void>()
+
+  const connect = (): Promise<WebSocket> => {
+    return new Promise((resolve) => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        return resolve(ws)
+      }
+
+      if (isConnecting) {
+        requestQueue.push(() => resolve(ws!))
+        return
+      }
+
+      isConnecting = true
+
+      const WebSocketImpl = (typeof window !== 'undefined' ? window.WebSocket : require('ws')) as typeof WebSocket
+      const newWs = new WebSocketImpl(WS_ENDPOINT)
+
+      newWs.onopen = () => {
+        ws = newWs
+        isConnecting = false
+        resolve(ws)
+        requestQueue.forEach(cb => cb())
+        requestQueue.length = 0
+      }
+
+      newWs.onmessage = (event) => {
+        const { type, payload } = JSON.parse(event.data.toString()) as WsMessage
+        const { key, value } = payload
+
+        if (type === 'GET_ITEM_SUCCESS') {
+          const resolveFunc = pendingRequests.get(key)
+          if (resolveFunc) {
+            resolveFunc(value ? JSON.stringify(value) : null)
+            pendingRequests.delete(key)
+          }
+        }
+      }
+
+      newWs.onerror = (err) => {
+        console.error('Mock WebSocket connection error:', err)
+        isConnecting = false
+      }
+    })
+  }
+
+  return {
+    async getItem(key: string): Promise<string | null> {
+      const socket = await connect()
+      return new Promise((resolve) => {
+        pendingRequests.set(key, resolve)
+        socket.send(JSON.stringify({ type: 'GET_ITEM', payload: { key } }))
+      })
+    },
+    async setItem(key: string, value: string): Promise<void> {
+      const socket = await connect()
+      socket.send(
+        JSON.stringify({
+          type: 'SET_ITEM',
+          payload: { key, value: JSON.parse(value) },
+        }),
+      )
+    },
+  }
+}

--- a/shared/services/src/tedrisat/service.ts
+++ b/shared/services/src/tedrisat/service.ts
@@ -29,4 +29,11 @@ export class TedrisatService {
   async getListCards(id: number) {
     return this.client<Card[]>(`/lists/${id}/cards`)
   }
+
+  async createCard(card: Card) {
+    return this.client<Card>('/cards', {
+      method: 'POST',
+      body: JSON.stringify(card),
+    })
+  }
 }

--- a/shared/services/src/tedrisat/types.ts
+++ b/shared/services/src/tedrisat/types.ts
@@ -1,10 +1,10 @@
 export type Card = {
   id: number
-  type: 'hadeeth' | 'vocabulary'
   author_id: number
   is_public: boolean
-  image_source: string
   content: any
+  type: 'hadeeth' | 'vocabulary'
+  image_source: string
 }
 
 export type List = {


### PR DESCRIPTION
## Teamhub Task Linki
--

## Açıklama
Mevcut mock servisi implementasyonu, mock servisi katmanını her uygulamanın kendi üzerinde ayrı birer servis çalıştırıyor, bu da mock servisinin kendi içerisinde stateless çalışmasına sebebiyet veriyor. Basic CRUD işlemlerini taklit edebilmemiz için applerin mock katmanı ya da tüm uygulamalar üzerinde çalışan tek bir katman olarak tasarlanmalı, ya da her uygulama üzerinde çalışan mock servisi, diğer mock servisleriyle konuşabilen bir yapıda olmalı.

Bu PR draft ve deneysel bir çalışmayı sunmak için açıldı. Gelecek iterasyonlarda böyle bir yapıya ihtiyaç duyulması halinde tekrar gündeme getirilebilir.