### PR TITLE
chore: setup post-checkout husky script

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 # Git sends three arguments to this hook:
 # $1: Ref of previous HEAD
 # $2: Ref of new HEAD


### PR DESCRIPTION
## Teamhub Task Linki
--

## Açıklama
Branch değişimlerinde paket versiyonları da değiştiği için her checkout sonrası `npm install` ile yeni paketleri yüklemek gerekiyor. Bu husky scripti her checkout sonrasında eğer ki `package-lock.json` içeriği değişmiş ise otomatik olarak npm install çekiyor. Böylece komutun çalıştırılması unutulması durumunda, geliştirici ortamı için minimum hatayı garanti edebiliriz.